### PR TITLE
Update braintree version to 9.13.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.braintreepayments.api:drop-in:6.13.0'
+    implementation 'com.braintreepayments.api:drop-in:6.16.0'
     implementation 'com.google.android.gms:play-services-wallet:16.0.0'
     implementation 'androidx.appcompat:appcompat:1.4.0-alpha03'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/example/ios/Flutter/Flutter.podspec
+++ b/example/ios/Flutter/Flutter.podspec
@@ -1,6 +1,6 @@
 #
-# NOTE: This podspec is NOT to be published. It is only used as a local source!
-#       This is a generated file; do not edit or check into version control.
+# This podspec is NOT to be published. It is only used as a local source!
+# This is a generated file; do not edit or check into version control.
 #
 
 Pod::Spec.new do |s|
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'BSD' }
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
   # Framework linking is handled by Flutter tooling, not CocoaPods.
   # Add a placeholder to satisfy `s.dependency 'Flutter'` plugin podspecs.
   s.vendored_frameworks = 'path/to/nothing'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,36 +1,36 @@
 PODS:
-  - Braintree/ApplePay (5.6.3):
+  - Braintree/ApplePay (5.26.0):
     - Braintree/Core
-  - Braintree/Card (5.6.3):
+  - Braintree/Card (5.26.0):
     - Braintree/Core
-  - Braintree/Core (5.6.3)
-  - Braintree/PaymentFlow (5.6.3):
-    - Braintree/Core
-    - Braintree/PayPalDataCollector
-  - Braintree/PayPal (5.6.3):
+  - Braintree/Core (5.26.0)
+  - Braintree/PaymentFlow (5.26.0):
     - Braintree/Core
     - Braintree/PayPalDataCollector
-  - Braintree/PayPalDataCollector (5.6.3)
-  - Braintree/ThreeDSecure (5.6.3):
+  - Braintree/PayPal (5.26.0):
+    - Braintree/Core
+    - Braintree/PayPalDataCollector
+  - Braintree/PayPalDataCollector (5.26.0)
+  - Braintree/ThreeDSecure (5.26.0):
     - Braintree/Card
     - Braintree/PaymentFlow
-  - Braintree/UnionPay (5.6.3):
+  - Braintree/UnionPay (5.26.0):
     - Braintree/Card
-  - Braintree/Venmo (5.6.3):
+  - Braintree/Venmo (5.26.0):
     - Braintree/Core
-  - BraintreeDropIn (9.4.0):
-    - Braintree/ApplePay (~> 5.6.1)
-    - Braintree/Card (~> 5.6.1)
-    - Braintree/Core (~> 5.6.1)
-    - Braintree/PayPal (~> 5.6.1)
-    - Braintree/ThreeDSecure (~> 5.6.1)
-    - Braintree/UnionPay (~> 5.6.1)
-    - Braintree/Venmo (~> 5.6.1)
+  - BraintreeDropIn (9.13.0):
+    - Braintree/ApplePay (~> 5.26)
+    - Braintree/Card (~> 5.26)
+    - Braintree/Core (~> 5.26)
+    - Braintree/PayPal (~> 5.26)
+    - Braintree/ThreeDSecure (~> 5.26)
+    - Braintree/UnionPay (~> 5.26)
+    - Braintree/Venmo (~> 5.26)
   - Flutter (1.0.0)
   - flutter_braintree (1.0.0):
-    - Braintree/ApplePay (~> 5.6.3)
-    - Braintree/PayPal (~> 5.6.3)
-    - BraintreeDropIn (= 9.4.0)
+    - Braintree/ApplePay (~> 5.26)
+    - Braintree/PayPal (~> 5.26)
+    - BraintreeDropIn (= 9.13.0)
     - Flutter
 
 DEPENDENCIES:
@@ -49,11 +49,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_braintree/ios"
 
 SPEC CHECKSUMS:
-  Braintree: cef7388a3647515f1e0861e52200c2f3dad0f98f
-  BraintreeDropIn: 89df35f840004affa22ebb8f06b12d20615411bf
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  flutter_braintree: 72276002464c36b1d5a6266fbdb94c0b600e62fd
+  Braintree: 53d39d5349a6316dc455b03334e869f43d6b51bd
+  BraintreeDropIn: 20b95f7acc61871d8229b5de0e9edbcf713c9cc0
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_braintree: 01af81bcbf3bffe95bb93a5ca1ca4482d4f11f26
 
 PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.15.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -163,7 +163,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -207,10 +207,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -247,6 +249,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -56,5 +56,7 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/ios/flutter_braintree.podspec
+++ b/ios/flutter_braintree.podspec
@@ -15,9 +15,9 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'BraintreeDropIn', '9.4.0'
-  s.dependency 'Braintree/PayPal', '~> 5.6.3'
-  s.dependency 'Braintree/ApplePay', '~> 5.6.3'
+  s.dependency 'BraintreeDropIn', '9.13.0'
+  s.dependency 'Braintree/PayPal', '~> 5.26'
+  s.dependency 'Braintree/ApplePay', '~> 5.26'
   s.ios.deployment_target = '12.0'
   s.swift_version = '5.0'
 end


### PR DESCRIPTION
PT - 3436518[iOS Braintree Upgrade]

Changes:

- Update BraintreeDropIn version to 9.13.0
- Update Braintree/PayPal version to 5.26
- Update Braintree/ApplePay version to 5.26